### PR TITLE
Prevent isolate from installing gems in other environments

### DIFF
--- a/lib/isolate/sandbox.rb
+++ b/lib/isolate/sandbox.rb
@@ -209,7 +209,7 @@ module Isolate
       fire :installing
 
       installable = entries.select do |e|
-        not e.specification && e.matches?(environment)
+        !e.specification && e.matches?(environment)
       end
 
       unless installable.empty?

--- a/test/test_isolate_sandbox.rb
+++ b/test/test_isolate_sandbox.rb
@@ -53,6 +53,15 @@ class TestIsolateSandbox < Isolate::Test
       Gem::DependencyInstaller.value.shift
   end
 
+  def test_activate_install_with_different_environment
+    s = sandbox :path => WITH_HOE, :install => true
+    s.environment(:borg) { gem 'foo' }
+
+    # This won't crash because it should not install or activate the env
+    s.activate
+    refute_equal 'foo', Gem::DependencyInstaller.value.shift[0]
+  end
+
   # TODO: cleanup with 2 versions of same gem, 1 activated
   # TODO: install with 1 older version, 1 new gem to be installed
 


### PR DESCRIPTION
When running isolate in a specific environment gems were being installed to other environments if they are not already present on the system.
