### PR TITLE
Uninitialized Constant error Gem::Deprecate

### DIFF
--- a/lib/isolate/sandbox.rb
+++ b/lib/isolate/sandbox.rb
@@ -324,7 +324,7 @@ module Isolate
       specs.uniq
     end
 
-    dep_module = Gem.const_defined?(:Deprecate) ? Gem::Deprecate : Deprecate
+    dep_module = defined?(Gem::Deprecate) ? Gem::Deprecate : Deprecate
     extend dep_module
     deprecate :index, :none, 2011, 11
   end


### PR DESCRIPTION
Fixes an uninitialized constant error on ruby-1.9.2 and rubygems-1.8.5, with rake-0.9.2 and hoe-2.10.0:

rake aborted!
uninitialized constant Gem::Deprecate
/gems/ruby-1.9.2-p290/gems/rake-0.9.2/lib/rake/ext/module.rb:36:in `const_missing'
/gems/ruby-1.9.2-p290/gems/isolate-3.1.1/lib/isolate/sandbox.rb:327:in`class:Sandbox'
/gems/ruby-1.9.2-p290/gems/isolate-3.1.1/lib/isolate/sandbox.rb:14:in `<module:Isolate>'
/gems/ruby-1.9.2-p290/gems/isolate-3.1.1/lib/isolate/sandbox.rb:9:in`<top (required)>'
