### PR TITLE
Fix dead Hoe link url

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -80,7 +80,7 @@ looking at the <tt>ISOLATE_ENV</tt>, <tt>RACK_ENV</tt>, and
 
 === Library Development
 
-If you're using Hoe[http://blog.zenspider.com/hoe] to manage your
+If you're using Hoe[https://www.zenspider.com/projects/hoe.html] to manage your
 library, you can use Isolate's Hoe plugin to automatically install
 your lib's development, runtime, and test dependencies without
 polluting your system RubyGems, and run your tests/specs in total


### PR DESCRIPTION
Hoe link http://blog.zenspider.com/hoe appears to be dead. Updated using link in https://github.com/seattlerb/hoe